### PR TITLE
Bump jsonwebtoken 9 -> 10 (rust_crypto backend)

### DIFF
--- a/jwt/Cargo.toml
+++ b/jwt/Cargo.toml
@@ -16,7 +16,7 @@ version = "0.3.1"
 
 [dependencies]
 base64 = "0.22"
-jsonwebtoken = "9"
+jsonwebtoken = { version = "10.3", default-features = false, features = ["rust_crypto"] }
 rsa = "0.9"
 serde = "1"
 sha2 = "0.10"

--- a/snowflake-api/Cargo.toml
+++ b/snowflake-api/Cargo.toml
@@ -37,7 +37,7 @@ reqwest-middleware = { version = "0.3.3", features = ["json"] }
 reqwest-retry = "0.6"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-snowflake-jwt = { version = "0.3", optional = true }
+snowflake-jwt = { version = "0.3", path = "../jwt", optional = true }
 thiserror = "1"
 url = "2"
 uuid = { version = "1", features = ["v4"] }


### PR DESCRIPTION
## Summary
- Bump `snowflake-jwt` to `jsonwebtoken 10.3` with the `rust_crypto` backend, dropping the ring-based `jsonwebtoken 9` flagged by RUSTSEC.
- Point `snowflake-api` at the local `../jwt` path crate so the bump propagates to downstream consumers.

## Test plan
- `cargo build` (workspace) passes.
- `cargo tree -i jsonwebtoken` shows only `10.4.0`.
- `cargo tree -i ring` shows only the safe `0.17.8` (the `jsonwebtoken 9 -> ring` path is gone).

Made with [Cursor](https://cursor.com)